### PR TITLE
[BUG FIX] Fixed options & subcommands being shared between commands.

### DIFF
--- a/examples/ExampleCommand.java
+++ b/examples/ExampleCommand.java
@@ -25,7 +25,7 @@ import com.seailz.discordjv.events.model.interaction.command.SlashCommandInterac
  * @see com.seailz.discordjv.command.listeners.MessageContextCommandListener
  * @see com.seailz.discordjv.command.listeners.UserContextCommandListener
  */
-public class ExampleCommand implements SlashCommandListener {
+public class ExampleCommand extends SlashCommandListener {
 
     /**
      * This is for sub commands, and options.

--- a/src/main/java/com/seailz/discordjv/DiscordJv.java
+++ b/src/main/java/com/seailz/discordjv/DiscordJv.java
@@ -480,7 +480,6 @@ public class DiscordJv {
             if (!(listener instanceof SlashCommandListener slashCommandListener)) return;
             if (slashCommandListener.getSubCommands().isEmpty()) return;
 
-            System.out.println(slashCommandListener + " has subcommands: ");
             for (SlashSubCommand subCommand : slashCommandListener.getSubCommands().keySet()) {
                 System.out.println("Registering subcommand " + subCommand.getName());
                 SubCommandListener subListener =
@@ -488,7 +487,6 @@ public class DiscordJv {
                                 slashCommandListener.getSubCommands().keySet().stream().toList()
                                         .indexOf(subCommand)
                         );
-                System.out.println("registering sub command for command " + name + ":" + subCommand.getName());
                 commandDispatcher.registerSubCommand(slashCommandListener, subCommand, subListener);
             }
         }

--- a/src/main/java/com/seailz/discordjv/DiscordJv.java
+++ b/src/main/java/com/seailz/discordjv/DiscordJv.java
@@ -481,7 +481,6 @@ public class DiscordJv {
             if (slashCommandListener.getSubCommands().isEmpty()) return;
 
             for (SlashSubCommand subCommand : slashCommandListener.getSubCommands().keySet()) {
-                System.out.println("Registering subcommand " + subCommand.getName());
                 SubCommandListener subListener =
                         slashCommandListener.getSubCommands().values().stream().toList().get(
                                 slashCommandListener.getSubCommands().keySet().stream().toList()

--- a/src/main/java/com/seailz/discordjv/command/listeners/slash/SlashCommandListener.java
+++ b/src/main/java/com/seailz/discordjv/command/listeners/slash/SlashCommandListener.java
@@ -1,22 +1,22 @@
 package com.seailz.discordjv.command.listeners.slash;
 
-import com.seailz.discordjv.command.listeners.CommandListener;
-import com.seailz.discordjv.events.model.interaction.command.CommandInteractionEvent;
-import com.seailz.discordjv.events.model.interaction.command.SlashCommandInteractionEvent;
 import com.seailz.discordjv.command.CommandOption;
 import com.seailz.discordjv.command.CommandOptionType;
 import com.seailz.discordjv.command.CommandType;
+import com.seailz.discordjv.command.listeners.CommandListener;
+import com.seailz.discordjv.events.model.interaction.command.CommandInteractionEvent;
+import com.seailz.discordjv.events.model.interaction.command.SlashCommandInteractionEvent;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public interface SlashCommandListener extends CommandListener {
+public abstract class SlashCommandListener implements CommandListener {
 
-    List<CommandOption> options = new ArrayList<>();
-    HashMap<SlashSubCommand, SubCommandListener> subCommands = new HashMap<>();
+    private final List<CommandOption> options = new ArrayList<>();
+    private final HashMap<SlashSubCommand, SubCommandListener> subCommands = new HashMap<>();
 
-    default void addSubCommandGroup(SubCommandGroup group) {
+    public void addSubCommandGroup(SubCommandGroup group) {
         options.add(new CommandOption(
                 group.getName(),
                 group.getDescription(),
@@ -29,7 +29,7 @@ public interface SlashCommandListener extends CommandListener {
         subCommands.putAll(group.getSubCommands());
     }
 
-    default void addSubCommand(SlashSubCommand subCommand, SubCommandListener listener) {
+    public void addSubCommand(SlashSubCommand subCommand, SubCommandListener listener) {
         options.add(new CommandOption(
                 subCommand.getName(),
                 subCommand.getDescription(),
@@ -46,33 +46,33 @@ public interface SlashCommandListener extends CommandListener {
      * Returns the type of command this listener is listening for.
      */
     @Override
-    default CommandType getType() {
+    public CommandType getType() {
         return CommandType.SLASH_COMMAND;
     }
 
     /**
      * @param event The event that was fired.
      */
-    void onCommand(SlashCommandInteractionEvent event);
+    protected abstract void onCommand(SlashCommandInteractionEvent event);
 
     /**
      * This method should not be overriden, it's used to call the {@link #onCommand(SlashCommandInteractionEvent)} method by the command dispatcher.
      */
     @Override
-    default void onCommand(CommandInteractionEvent event) {
+    public void onCommand(CommandInteractionEvent event) {
         onCommand((SlashCommandInteractionEvent) event);
     }
 
-    default List<CommandOption> getOptions() {
+    public List<CommandOption> getOptions() {
         return options;
     }
 
-    default SlashCommandListener addOption(CommandOption option) {
+    public SlashCommandListener addOption(CommandOption option) {
         options.add(option);
         return this;
     }
 
-    default HashMap<SlashSubCommand, SubCommandListener> getSubCommands() {
+    public HashMap<SlashSubCommand, SubCommandListener> getSubCommands() {
         return subCommands;
     }
 }


### PR DESCRIPTION
## Pull Request

- [x] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [x] Internal code
- [ ] Library
- [x] Documentation

<!-- Replace 0 with the issue to close that is linked to this PR (if there is one) -->
Closes #0

## Description
Since all variables in interfaces are static, options and sub commands were being shared if you registered multiple commands. This PR fixes that by making SlashCommandListener.java an abstract class, rather than an interface. This is not necessary for the other command listeners (like message context), since they do not have options or sub commands.
I've also updated the examples to reflect this change.

As such this PR **does include a breaking change**:

# BREAKING CHANGES:
`implements SlashCommandListener` -> `extends SlashCommandListener`