### PR TITLE
[BUG FIX] Fixed retrieving roles when decompiling Member object.

### DIFF
--- a/src/main/java/com/seailz/discordjv/model/guild/Guild.java
+++ b/src/main/java/com/seailz/discordjv/model/guild/Guild.java
@@ -754,19 +754,6 @@ public record Guild(
         return roles;
     }
 
-    public Role getRoleById(String id) {
-        return Role.decompile(
-                new DiscordRequest(
-                        new JSONObject(),
-                        new HashMap<>(),
-                        URLS.GET.GUILDS.ROLES.GET_GUILD_ROLE.replace("{guild.id}", this.id).replace("{role.id}", id),
-                        discordJv,
-                        URLS.GET.GUILDS.ROLES.GET_GUILD_ROLE,
-                        RequestMethod.GET
-                ).invoke().body()
-        );
-    }
-
     public CreateGuildChannelAction createChannel(String name, ChannelType type) {
         return new CreateGuildChannelAction(name, type, this, discordJv);
     }

--- a/src/main/java/com/seailz/discordjv/model/guild/Member.java
+++ b/src/main/java/com/seailz/discordjv/model/guild/Member.java
@@ -15,10 +15,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 /**
  * Represents a member of a guild
@@ -106,21 +103,18 @@ public record Member(
             avatar = null;
         }
 
-        /*try {
+        if (obj.has("roles")) {
             if (guild != null) {
                 List<Role> rolesList = new ArrayList<>();
                 for (Object o : obj.getJSONArray("roles")) {
-                    try {
-                        rolesList.add(guild.getRoleById(o.toString()));
-                    } catch (DiscordRequest.DiscordAPIErrorException ignored) {
-                        continue;
-                    }
+                    guild.roles().stream()
+                            .filter(role -> role.id().equals(o.toString()))
+                            .findFirst()
+                            .ifPresent(rolesList::add);
                 }
                 roles = rolesList.toArray(new Role[0]);
             }
-        } catch (JSONException e) {
-            roles = null;
-        }*/
+        }
 
         try {
             joinedAt = obj.getString("joined_at");

--- a/src/main/java/com/seailz/discordjv/utils/URLS.java
+++ b/src/main/java/com/seailz/discordjv/utils/URLS.java
@@ -56,7 +56,7 @@ public final class URLS {
                  * @param {guild.id} The guild to create the rule in
                  */
                 public static final String CREATE_AUTO_MOD_RULE = "/guilds/{guild.id}/auto-moderation/rules";
-            }
+             }
 
             public static class CHANNELS {
                 /**
@@ -218,7 +218,6 @@ public final class URLS {
 
             public static class ROLES {
                 public static String GET_GUILD_ROLES = "/guilds/{guild.id}/roles";
-                public static String GET_GUILD_ROLE = "/guilds/{guild.id}/role/{role.id}";
             }
         }
 


### PR DESCRIPTION
## Pull Request

- [ ] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [ ] Internal code
- [ ] Library
- [ ] Documentation

<!-- Replace 0 with the issue to close that is linked to this PR (if there is one) -->
Closes #0

## Description
This PR fixes the retrieval of roles of a member when decompiling a member object.
I've also removed the `Guild#getRole` method as apparently that endpoint doesn't exist.